### PR TITLE
Make it work when embedded in an Electron binary

### DIFF
--- a/electron_client/main.js
+++ b/electron_client/main.js
@@ -25,7 +25,7 @@ const screenSelectView = './views/screen_select.html'
 const sessionLinkView = './views/session_link.html'
 
 const webPreferences = {
-  preload: path.resolve('./preload.js'),
+  preload: path.join(__dirname, 'preload.js'),
   nodeIntegration: false,
   contextIsolation: true,
   enableRemoteModule: false


### PR DESCRIPTION
`path.resolve(x)` will resolve `x` relative to the current working directory, which is the top of the source directory when invoked via `electron .`/`npm start`, but is several directories up when embedded with an Electron binary. `__dirname` is here to help. `path.resolve` does not appear to be required in this case.